### PR TITLE
Fix path to own repo

### DIFF
--- a/drupal/usage_scenario.yml
+++ b/drupal/usage_scenario.yml
@@ -23,7 +23,7 @@ services:
   gcb-puppeteer:
     image: greencoding/puppeteer-chrome
     setup-commands:
-      - cp /tmp/repo/drupal/puppeteer-flow.js /var/www/puppeteer-flow.js
+      - cp /tmp/repo/puppeteer-flow.js /var/www/puppeteer-flow.js
     networks:
       - drupal-mariadb-network
 

--- a/jmeter/usage_scenario.yml
+++ b/jmeter/usage_scenario.yml
@@ -22,7 +22,7 @@ flow:
     container: gcb-jmeter
     commands:
       - type: console
-        command: jmeter -Jhostname=gcb-backend -Jport=8080 -JnumExecutions=1 -JnumUser=1 -JrampUp=0 -JnumProducts=1 -JthinkTimeMin=1000 -JthinkTimeAdditionalRange=0 -JpauseBeforeExecution=0 -JpauseAfterExecution=0 -JloggingEnabled=true -n -t /tmp/repo/jmeter/jmeter-test-plan.jmx
+        command: jmeter -Jhostname=gcb-backend -Jport=8080 -JnumExecutions=1 -JnumUser=1 -JrampUp=0 -JnumProducts=1 -JthinkTimeMin=1000 -JthinkTimeAdditionalRange=0 -JpauseBeforeExecution=0 -JpauseAfterExecution=0 -JloggingEnabled=true -n -t /tmp/repo/jmeter-test-plan.jmx
         log-stdout: true
         read-notes-stdout: true
         read-sci-stdout: true

--- a/wordpress-official-data/usage_scenario.yml
+++ b/wordpress-official-data/usage_scenario.yml
@@ -37,7 +37,7 @@ services:
   gcb-puppeteer:
     image: greencoding/puppeteer-chrome
     setup-commands:
-      - cp /tmp/repo/wordpress-official-data/puppeteer-flow.js /var/www/puppeteer-flow.js
+      - cp /tmp/repo/puppeteer-flow.js /var/www/puppeteer-flow.js
     networks:
       - gcb-wordpress-mariadb-network
     deploy:

--- a/wordpress-official-starter/usage_scenario.yml
+++ b/wordpress-official-starter/usage_scenario.yml
@@ -8,7 +8,7 @@ services:
   gcb-puppeteer:
     image: greencoding/puppeteer-chrome
     setup-commands:
-      - cp /tmp/repo/wordpress-official-starter/puppeteer-flow.js /var/www/puppeteer-flow.js
+      - cp /tmp/repo/puppeteer-flow.js /var/www/puppeteer-flow.js
     networks:
       - gcb-mariadb-wordpress-network
 

--- a/wordpress-vs-hugo/hugo-apache/usage_scenario.yml
+++ b/wordpress-vs-hugo/hugo-apache/usage_scenario.yml
@@ -9,7 +9,7 @@ services:
     networks:
       - gcb-hugo-apache-network
     setup-commands:
-      - cp -R /tmp/repo/wordpress-vs-hugo/hugo-apache/htdocs /usr/local/apache2/
+      - cp -R /tmp/repo/htdocs /usr/local/apache2/
   gcb-curl:
     # Newer version of the curl image lead to an error with Docker rootless https://github.com/curl/curl-container/issues/55
     image: curlimages/curl:8.1.0


### PR DESCRIPTION
Some example applications are using files from the own repository for the measurement run.

Due to changes of https://github.com/green-coding-solutions/green-metrics-tool/pull/767 the paths are not correct anymore, because the repo name is not part of the path anymore.